### PR TITLE
feat: add paste option

### DIFF
--- a/examples/main.js
+++ b/examples/main.js
@@ -1,3 +1,4 @@
+// this code was generated using https://github.com/antfu/retypewriter
 import { createApp } from 'vue'
 import { createRouter, createWebHistory } from 'vue-router'
 import routes from 'virtual:generated-pages'

--- a/examples/main.js.retypewriter
+++ b/examples/main.js.retypewriter
@@ -56,4 +56,37 @@ const router = createRouter({
 app.use(router)
 app.mount('#app')
 
+--08----------
+// this code was generated using
+import { createApp } from 'vue'
+import { createRouter, createWebHistory } from 'vue-router'
+import routes from 'virtual:generated-pages'
+import App from './App.vue'
+
+const app = createApp(App)
+const router = createRouter({
+  history: createWebHistory(),
+  routes,
+})
+app.use(router)
+app.mount('#app')
+
+--09----------
+// this code was generated using https://github.com/antfu/retypewriter
+import { createApp } from 'vue'
+import { createRouter, createWebHistory } from 'vue-router'
+import routes from 'virtual:generated-pages'
+import App from './App.vue'
+
+const app = createApp(App)
+const router = createRouter({
+  history: createWebHistory(),
+  routes,
+})
+app.use(router)
+app.mount('#app')
+
+-----options--
+wait: 0
+paste: true
 --------------

--- a/examples/main.js.retypewriter
+++ b/examples/main.js.retypewriter
@@ -87,6 +87,6 @@ app.use(router)
 app.mount('#app')
 
 -----options--
-wait: 0
+wait: 200
 paste: true
 --------------

--- a/packages/core/src/animation/typewriter.ts
+++ b/packages/core/src/animation/typewriter.ts
@@ -26,8 +26,11 @@ export async function *typingAnimator(
       case 'init':
         break
       case 'snap-start':
-        if (step.index)
-          await sleep(randRange(700, 1000))
+        if (step.index) {
+          const { wait } = getOptions(step.snap)
+
+          await sleep(wait !== undefined ? wait : randRange(700, 1000))
+        }
         if (getOptions(step.snap).pause) {
           yield {
             type: 'action-pause',
@@ -41,6 +44,9 @@ export async function *typingAnimator(
         break
       case 'insert':
         await sleep(getTimeout(step.char, 1.2))
+        break
+      case 'paste':
+        await sleep(randRange(100, 200))
         break
       case 'removal':
         await sleep(randRange(0, 5))

--- a/packages/core/src/state/patch.ts
+++ b/packages/core/src/state/patch.ts
@@ -9,7 +9,7 @@ export function diff(a: string, b: string): Diff[] {
   return delta
 }
 
-export function calculatePatch(diff: Diff[]): Patch[] {
+export function calculatePatch(diff: Diff[], isPasted?: boolean): Patch[] {
   const patches: Patch[] = []
 
   let cursor = 0
@@ -28,7 +28,7 @@ export function calculatePatch(diff: Diff[]): Patch[] {
     else if (change[0] === 1) {
       const content = change[1]
       patches.push({
-        type: 'insert',
+        type: isPasted ? 'paste' : 'insert',
         cursor,
         content,
       })

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -4,13 +4,19 @@ export interface InsertPatch {
   content: string
 }
 
+export interface PastePatch {
+  type: 'paste'
+  cursor: number
+  content: string
+}
+
 export interface RemovalPatch {
   type: 'removal'
   cursor: number
   length: number
 }
 
-export type Patch = InsertPatch | RemovalPatch
+export type Patch = InsertPatch | PastePatch | RemovalPatch
 
 export interface Slice {
   content: string
@@ -26,6 +32,7 @@ export interface Snapshot {
 export interface SnapshotOptions {
   wait?: number
   pause?: boolean
+  paste?: boolean
 }
 
 export interface AnimatorStepInsert {
@@ -33,6 +40,12 @@ export interface AnimatorStepInsert {
   cursor: number
   content: string
   char: string
+}
+
+export interface AnimatorStepPaste {
+  type: 'paste'
+  cursor: number
+  content: string
 }
 
 export interface AnimatorStepRemoval {
@@ -82,6 +95,7 @@ export interface AnimatorStepActionPause {
 
 export type AnimatorStep =
   | AnimatorStepInsert
+  | AnimatorStepPaste
   | AnimatorStepRemoval
   | AnimatorStepInit
   | AnimatorStepPatch

--- a/packages/vscode/src/play.ts
+++ b/packages/vscode/src/play.ts
@@ -147,6 +147,14 @@ export async function playStart(arg?: TextDocument | Uri) {
         await editor.edit(edit => edit.replace(new Range(0, 0, Infinity, Infinity), snap.content))
         break
 
+      case 'paste':
+        await editor.edit(edit => edit.insert(
+          doc.positionAt(snap.cursor - snap.content.length),
+          snap.content,
+        ))
+        setCursor(snap.cursor)
+        break
+
       case 'insert':
         await editor.edit(edit => edit.insert(
           doc.positionAt(snap.cursor - 1),


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Hello, I just tried this tool for markdown files and found that writing some parts might not seem natural (like links), so I decided to create an option for pasting text

Example syntax:

```js
--01----------

--02----------
// see
--03----------
// see https://github.com/antfu/retypewriter/
-----options--
paste: true
wait: 0
--------------
```

I also implemented the `wait` option as you can see.

### Additional context

It would be nice if autodetection of inserting text or finding links was implemented in the future.

btw why was the remove snap function removed from CodeLens? The commented code seems to work

<!-- e.g. is there anything you'd like reviewers to focus on? -->
